### PR TITLE
Patch to fix default badge color, and prep for release 1.0.3

### DIFF
--- a/ActionUserCounter.py
+++ b/ActionUserCounter.py
@@ -225,7 +225,7 @@ if __name__ == "__main__" :
     
     color = sys.argv[5].strip()
     if len(color) == 0 :
-        color = '#4c1'
+        color = '#007ec6'
     
     includeLogo = sys.argv[6].strip().lower() == "true"
     

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 
+## [1.0.3] - 2021-09-30
+
+### Fixed
+* Changed the default badge color to the shade of blue that is commonly used
+  by Shields' badges for those badges that are informational. Our previous use
+  of green was inconsistent with the common use of green for a passing status.
+  Badges with counts of users is not a status that can be passed or failed. It
+  is strictly informational, and potentially useful to maintainers of actions
+  to know size of user-base and thus scale of the effects of potential changes.
+  Users can still override the color to any that they desire with the color input.
+
+
 ## [1.0.2] - 2021-08-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2021-08-19
+## [Unreleased] - 2021-09-30
 
 ### Added
   

--- a/README.md
+++ b/README.md
@@ -478,7 +478,8 @@ action will create it.
 ### `color`
 
 This is the color for the right side of the badge (the side with the count
-of action users). The default is a shade of green. You can pass 3-digit hex
+of action users). The default is the shade of blue that is currently
+used by Shields to designate that the badge is "informational". You can pass 3-digit hex
 (e.g., `color: '#333'`), 6-digit hex (e.g., `color: '#343434'`), or named
 colors (e.g., `blue`). Anything that is valid in CSS, SVG, etc is valid
 for this input. However, the action does not do any validation of the color that 
@@ -609,7 +610,7 @@ jobs:
       with:
         action-list: owner/action # This input is REQUIRED.
         target-directory: '' # Default is root of repository.
-        color: '#4c1' # A bright shade of green
+        color: '#007ec6' # The shade of blue used by Shields for informational badges
         include-logo: true
         named-logo: githubactions # Defaults to the GitHub Actions logo
         style: flat # Which is Shields's default as well

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ inputs:
   color:
     description: 'The color for the right side of the badge'
     required: false
-    default: '#4c1' # A bright shade of green
+    default: '#007ec6' # The shade of blue used by Shields for informational badges
   include-logo:
     description: 'If true will include a named logo on the left'
     required: false

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -57,7 +57,7 @@ class TestIntegration(unittest.TestCase) :
             except ValueError:
                 self.fail("count not an int")
             #self.assertTrue(messageParts[1].startswith("repo"))
-            self.assertEqual("#4c1", d["color"])
+            self.assertEqual("#007ec6", d["color"])
             self.assertEqual("githubactions", d["namedLogo"])
             self.assertFalse("style" in d)
 


### PR DESCRIPTION
## Summary
This is a patch to fix the default badge color. The prior default of green is confusing as it implies a status that has passed. The badge is purely informational to help maintainers understand size of user-base and thus scale of potential changes. Blue is the accepted convention for informational badges.

Upon merging this PR, a patch level release should be made.

## Closing Issues
Closes #9 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
