### PR TITLE
Prevent action from updating badge JSON file for count of 0

### DIFF
--- a/ActionUserCounter.py
+++ b/ActionUserCounter.py
@@ -76,7 +76,14 @@ def executeQuery(owner, actionName, failOnError) :
         exit(exitCode if failOnError else 0)
     result = json.loads(result)
     if "total_count" in result :
-        return result["total_count"]
+        count = result["total_count"]
+        if count == 0 :
+            print("WARNING: Code query returned 0 results for action:", actionName)
+            print("Query result:")
+            print(result)
+            print("If you think this is a bug in the count-action-users action,")
+            print("please include the above in your issue report.")
+        return count
     else :
         print("Error: total_count missing from GitHub API query result")
         exitCode = 1
@@ -97,7 +104,8 @@ def collectRepoCounts(actionList, failOnError, queryDelay) :
     for i, action in enumerate(actionList) :
         owner, actionName = splitActionOwnerName(action)
         count = executeQuery(owner, actionName, failOnError)
-        countMap[actionName] = formatCount(count)
+        if count > 0 :
+            countMap[actionName] = formatCount(count)
         if i+1 < len(actionList) :
             time.sleep(queryDelay)
     return countMap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2021-09-30
+## [Unreleased] - 2021-12-13
 
 ### Added
   
@@ -15,6 +15,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+
+
+## [1.0.4] - 2021-12-13
+
+### Changed
+* The base Docker image is now set to a specific version tag of pyaction,
+  specifically 4.0.0.
+
+### Fixed
+* Query results should never be 0 since the workflow running the action is
+  referencing the name of the workflow whose users are to be counted. GitHub
+  code search API periodically returns 0 results, typically correcting itself next
+  run. This patch prevents the badge JSON file from being written if result is 0.
 
 
 ## [1.0.3] - 2021-09-30

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # https://www.cicirello.org/
 # Licensed under the MIT License.
 
-FROM ghcr.io/cicirello/pyaction:4
+FROM ghcr.io/cicirello/pyaction:4.0.0
 
 COPY ActionUserCounter.py /ActionUserCounter.py
 ENTRYPOINT ["/ActionUserCounter.py"]


### PR DESCRIPTION
## Summary
Prevent action from updating badge JSON file for count of 0. Such a count is likely an error in code search API. Count can't be 0 since the workflow running the action is referencing the action whose users are counted, and should contribute 1 to the count.

## Closing Issues
Closes #11 
