### PR TITLE
Disabled pycache

### DIFF
--- a/ActionUserCounter.py
+++ b/ActionUserCounter.py
@@ -1,8 +1,8 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S python3 -B
 #
 # count-action-users: Generates Shields endpoint with number of users of a GitHub Action
 # 
-# Copyright (c) 2021 Vincent A Cicirello
+# Copyright (c) 2021-2022 Vincent A Cicirello
 # https://www.cicirello.org/
 #
 # MIT License

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+* Disabled pycache to protect against potential future bug. Currently
+  no imports so no pycache created, but if future versions import
+  local py modules, a pycache would be created during run in repo. Disabled
+  creation of pycache now to avoid.
 
 
 ## [1.0.5] - 2022-03-04


### PR DESCRIPTION
## Summary
Disabled pycache to protect against potential future bug. Currently
no imports so no pycache created, but if future versions import
local py modules, a pycache would be created during run in repo. Disabled
creation of pycache now to avoid.
