### PR TITLE
Replaced usage of the deprecated set-output workflow command

### DIFF
--- a/ActionUserCounter.py
+++ b/ActionUserCounter.py
@@ -72,7 +72,7 @@ def executeQuery(owner, actionName, failOnError) :
     if exitCode != 0 :
         print("Error: An error with code", exitCode, "occurred during GitHub API query.")
         print(result)
-        print("::set-output name=exit-code::" + str(exitCode))
+        set_output("exit-code", exitCode)
         exit(exitCode if failOnError else 0)
     result = json.loads(result)
     if "total_count" in result :
@@ -87,7 +87,7 @@ def executeQuery(owner, actionName, failOnError) :
     else :
         print("Error: total_count missing from GitHub API query result")
         exitCode = 1
-        print("::set-output name=exit-code::" + str(exitCode))
+        set_output("exit-code", exitCode)
         exit(exitCode if failOnError else 0)
 
 def collectRepoCounts(actionList, failOnError, queryDelay) :
@@ -183,7 +183,7 @@ def writeToFiles(endpointMap, failOnError) :
         except:
             print("Error: Failed while writing:", filename)
             exitCode = 2
-            print("::set-output name=exit-code::" + str(exitCode))
+            set_output("exit-code", exitCode)
             exit(exitCode if failOnError else 0)
     return allFilenames
 
@@ -219,9 +219,19 @@ def commitAndPush(allFilenames, name, login, failOnError) :
             if r[1] != 0 :
                 print("Error: push failed.")
                 exitCode = 3
-                print("::set-output name=exit-code::" + str(exitCode))
+                set_output("exit-code", exitCode)
                 exit(exitCode if failOnError else 0)
 
+def set_output(name, value) :
+    """Sets an action output.
+
+    Keyword arguments:
+    name - The output name
+    value - The output value
+    """
+    with open(os.environ["GITHUB_OUTPUT"], "a") as f :
+        print("{0}={1}".format(name, value), file=f)
+    
 if __name__ == "__main__" :
     actionList = sys.argv[1].strip().replace(",", " ").split()
 
@@ -269,5 +279,5 @@ if __name__ == "__main__" :
     if commit and len(allFilenames) > 0 :
         commitAndPush(allFilenames, "github-actions", "41898282+github-actions[bot]", failOnError)
     
-    print("::set-output name=exit-code::" + str(exitCode))
+    set_output("exit-code", exitCode)
     

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-10-05
+## [Unreleased] - 2022-10-20
 
 ### Added
   
@@ -15,10 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
-* Disabled pycache to protect against potential future bug. Currently
-  no imports so no pycache created, but if future versions import
-  local py modules, a pycache would be created during run in repo. Disabled
-  creation of pycache now to avoid.
+
+### Dependencies
+
+
+## [1.0.6] - 2022-10-20
+
+### Fixed
+* Replaced the usage of GitHub Action's deprecated `set-output` workflow command with the new `$GITHUB_OUTPUT`
+  environment file.
+* Disabled pycache to protect against potential future bug. Currently no imports so no pycache created, but if future 
+  versions import local py modules, a pycache would be created during run in repo. Disabled creation of pycache now to avoid.
 
 ### Dependencies
 * Bump cicirello/pyaction from 4.2.0 to 4.10.0, including upgrading Python within the Docker container to 3.10.7


### PR DESCRIPTION
## Summary
Replaced usage of the deprecated set-output workflow command.

## Closing Issues
Closes #35 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
