### PR TITLE
Bump Python to 3.12 in CI/CD workflows when running unit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.12'
 
     - name: Run Python unit tests
       run: python3 -u -m unittest tests/tests.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2023-09-21
+## [Unreleased] - 2023-10-05
 
 ### Added
   
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+### CI/CD
+* Bump Python to 3.12 in CI/CD workflows when running unit tests.
+
 ### Dependencies
 * Bump cicirello/pyaction from 4.10.0 to 4.24.0, including bumping Python inside the Docker container to 3.11.
 
@@ -23,10 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.6] - 2022-10-20
 
 ### Fixed
-* Replaced the usage of GitHub Action's deprecated `set-output` workflow command with the new `$GITHUB_OUTPUT`
-  environment file.
-* Disabled pycache to protect against potential future bug. Currently no imports so no pycache created, but if future 
-  versions import local py modules, a pycache would be created during run in repo. Disabled creation of pycache now to avoid.
+* Replaced the usage of GitHub Action's deprecated `set-output` workflow command with the new `$GITHUB_OUTPUT` environment file.
+* Disabled pycache to protect against potential future bug. Currently no imports so no pycache created, but if future versions import local py modules, a pycache would be created during run in repo. Disabled creation of pycache now to avoid.
 
 ### Dependencies
 * Bump cicirello/pyaction from 4.2.0 to 4.10.0, including upgrading Python within the Docker container to 3.10.7


### PR DESCRIPTION
## Summary
Bump Python to 3.12 in CI/CD workflows when running unit tests

## Closing Issues
Closes #59 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
