### PR TITLE
Bumps cicirello/pyaction to 3.13.5-gh-2.75.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2025-05-20
+## [Unreleased] - 2025-07-15
 
 ### Added
   
@@ -19,7 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### CI/CD
 
 ### Dependencies
-* Bump cicirello/pyaction from 4.25.0 to 4.33.0
+* Switch to the new tag scheme of cicirello/pyaction
+* Bump cicirello/pyaction to 3.13.5-gh-2.75.1
 
 
 ## [1.0.7] - 2023-10-05

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # https://www.cicirello.org/
 # Licensed under the MIT License.
 
-FROM ghcr.io/cicirello/pyaction:4.33.0
+FROM ghcr.io/cicirello/pyaction:3.13.5-gh-2.75.1
 
 COPY ActionUserCounter.py /ActionUserCounter.py
 ENTRYPOINT ["/ActionUserCounter.py"]


### PR DESCRIPTION
## Summary
Bumps cicirello/pyaction to 3.13.5-gh-2.75.1.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
